### PR TITLE
Add endpoint for minecraft:twitch usernames

### DIFF
--- a/app/Http/Controllers/GeneralController.php
+++ b/app/Http/Controllers/GeneralController.php
@@ -63,6 +63,10 @@ class GeneralController extends Controller
         return $this->handleRequest($id, 'minecraft_nl', 'text/plain');
     }
 
+    public function minecraft_twitch_nl(string $id) {
+        return $this->handleRequest($id, 'minecraft_twitch_nl', 'text/plain');
+    }
+
     public function minecraft_json_array(string $id) {
         return $this->handleRequest($id, 'minecraft_json_array', 'application/json');
     }

--- a/app/Repo/WhitelistRepository.php
+++ b/app/Repo/WhitelistRepository.php
@@ -101,6 +101,16 @@ class WhitelistRepository
     }
 
     /**
+     * Process to filter and get all valid minecraft:twitch usernames
+     * @param Collection $list
+     * @return array
+     */
+    private function minecraftTwitchNameProcess(Collection $list): array
+    {
+        return $this->minecraftProcess($list)->map([$this, 'mapMinecraftTwitchName'])->flatten()->toArray();
+    }
+
+    /**
      * Process to filter and get all valid minecraft uuids and names in the vanilla whitelist format
      * @param Collection $list
      * @return array
@@ -194,6 +204,20 @@ class WhitelistRepository
     public function mapMinecraftName(Whitelist $value): string
     {
         return $value->minecraft->username;
+    }
+
+    /**
+     * Maps a whitelist entry to the minecraft:twitch username
+     * @param Whitelist $value
+     * @return string
+     */
+    public function mapMinecraftTwitchName(Whitelist $value): string
+	{
+		if (strcasecmp($value->minecraft->username, $value->user->name) === 0) {
+				return $value->minecraft->username;
+		} else {
+			return $value->minecraft->username . ':' . $value->user->name;
+		}
     }
 
     /**
@@ -302,6 +326,16 @@ class WhitelistRepository
     public function minecraft_nl(Collection $list): string
     {
         return join("\n", $this->minecraftNameProcess($list));
+    }
+
+    /**
+     * Formats the minecraft:twitch usernames to a newline string
+     * @param Collection $list
+     * @return string
+     */
+    public function minecraft_twitch_nl(Collection $list): string
+    {
+        return join("\n", $this->minecraftTwitchNameProcess($list));
     }
 
     /**

--- a/app/Repo/WhitelistRepository.php
+++ b/app/Repo/WhitelistRepository.php
@@ -213,8 +213,8 @@ class WhitelistRepository
      */
     public function mapMinecraftTwitchName(Whitelist $value): string
 	{
-		if (strcasecmp($value->minecraft->username, $value->user->name) === 0) {
-				return $value->minecraft->username;
+		if (is_null($value->user) || strcasecmp($value->minecraft->username, $value->user->name) === 0) {
+		    return $value->minecraft->username;
 		} else {
 			return $value->minecraft->username . ':' . $value->user->name;
 		}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ $router->group(['prefix' => '{id}'], function() use ($router) {
 
     $router->get('minecraft_csv', 'GeneralController@minecraft_csv');
     $router->get('minecraft_nl', 'GeneralController@minecraft_nl');
+    $router->get('minecraft_twitch_nl', 'GeneralController@minecraft_twitch_nl');
     $router->get('minecraft_json_array', 'GeneralController@minecraft_json_array');
     $router->get('minecraft_uuid_csv', 'GeneralController@minecraft_uuid_csv');
     $router->get('minecraft_uuid_nl', 'GeneralController@minecraft_uuid_nl');


### PR DESCRIPTION
This adds an API endpoint for lines of `<minecraft username>:<twitch username>`
for users where these differ (by more than just case).

This is the server-side companion to GoryMoon/PlayerMobs#7

Please note that while I think this should work, I have not been able to
get a working test environment running, so it may not work as-is. It's
possible (and probably likely) that I missed something.